### PR TITLE
Remove threadpools

### DIFF
--- a/src/haloniumpkg/service.nim
+++ b/src/haloniumpkg/service.nim
@@ -250,7 +250,6 @@ proc stop*(service: Service) =
 
   try:
     service.process.close()
-    joinThread(backgroundThread)
     service.process.terminate()
     discard service.process.waitForExit(1)
     service.process.kill()


### PR DESCRIPTION
Attempt to port away from `threadpool` module. It is not really needed, and known to be buggy.