### PR TITLE
expose running status

### DIFF
--- a/src/halonium/service.nim
+++ b/src/halonium/service.nim
@@ -365,3 +365,5 @@ proc start*(service: Service) =
     if count >= SERVICE_RETRY_LIMIT:
       raise newWebDriverException(fmt"Cannot connect to service {service.path}. \l{service.process.outputStream.readAll}")
   spawn service.watchOutput()
+
+proc running*(service: Service): bool = service.process.running

--- a/src/halonium/webdriver.nim
+++ b/src/halonium/webdriver.nim
@@ -673,6 +673,12 @@ proc close*(session: Session) =
   ## Closes the current session
   discard session.execute(Command.Quit, stopOnException=false)
 
+proc running*(session: Session): bool =
+  result = case session.kind
+  of LocalSession: session.service.running
+  of RemoteSession:
+    true
+
 proc stop*(session: Session) =
   session.close()
   case session.kind

--- a/src/halonium/webdriver.nim
+++ b/src/halonium/webdriver.nim
@@ -676,8 +676,7 @@ proc close*(session: Session) =
 proc running*(session: Session): bool =
   result = case session.kind
   of LocalSession: session.service.running
-  of RemoteSession:
-    true
+  of RemoteSession: session.service.isConnectable()
 
 proc stop*(session: Session) =
   session.close()


### PR DESCRIPTION
only work for local session, for remote session, always returns true, since it's http api.